### PR TITLE
Set eq is zero when only one player

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -74,6 +74,10 @@ func calcEquity(ctx context.Context, q *query.Queries, updatedCh chan struct{}) 
 
 	if len(players) <= 1 {
 		// if players is less than 2, no need to calculate equity
+		if err := q.ResetEquity(ctx); err != nil {
+			return fmt.Errorf("db.ResetEquity(): %w", err)
+		}
+		updatedCh <- struct{}{}
 		return nil
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for equity updates in scenarios with minimal participants by ensuring values are reset and updated consistently, providing more accurate system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->